### PR TITLE
refinements for examples and test cases

### DIFF
--- a/examples/java/StellarExample.java
+++ b/examples/java/StellarExample.java
@@ -14,7 +14,7 @@ public class StellarExample {
 
     Account sourceAccount = new Account(sourceKeypair, 3009998980382720L);
 
-    PaymentOperation operation = new PaymentOperation.Builder(destination, new AssetTypeNative(), 20000000).build();
+    PaymentOperation operation = new PaymentOperation.Builder(destination, new AssetTypeNative(), 20000000L).build();
     Transaction transaction = new Transaction.Builder(sourceAccount)
       .addOperation(operation)
       .addMemo(Memo.text("Java FTW!"))

--- a/src/main/java/org/stellar/base/Memo.java
+++ b/src/main/java/org/stellar/base/Memo.java
@@ -1,5 +1,6 @@
 package org.stellar.base;
 
+import com.google.common.base.Strings;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.stellar.base.xdr.MemoType;
@@ -40,8 +41,9 @@ public class Memo {
     public static org.stellar.base.xdr.Memo text(String text) {
         checkNotNull(text, "text cannot be null");
 
-        if (text.getBytes(StandardCharsets.UTF_8).length > 28) {
-            throw new MemoTooLongException("text must be <= 28 bytes.");
+        int length = text.getBytes((StandardCharsets.UTF_8)).length;
+        if (length > 28) {
+            throw new MemoTooLongException("text must be <= 28 bytes. length=" + String.valueOf(length));
         }
 
         org.stellar.base.xdr.Memo memo = new org.stellar.base.xdr.Memo();

--- a/src/main/java/org/stellar/base/Memo.java
+++ b/src/main/java/org/stellar/base/Memo.java
@@ -91,8 +91,7 @@ public class Memo {
      */
     public static org.stellar.base.xdr.Memo hash(String hexString) throws DecoderException {
         checkNotNull(hexString, "hexString cannot be null");
-        Hex hexCodec = new Hex();
-        byte[] decoded = hexCodec.decodeHex(hexString.toCharArray());
+        byte[] decoded = Hex.decodeHex(hexString.toCharArray());
         return Memo.hash(decoded);
     }
 

--- a/src/test/java/org/stellar/base/AccountTest.java
+++ b/src/test/java/org/stellar/base/AccountTest.java
@@ -1,10 +1,11 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
-public class AccountTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AccountTest  {
     @Test
     public void testNullArguments() {
         try {

--- a/src/test/java/org/stellar/base/AssetTest.java
+++ b/src/test/java/org/stellar/base/AssetTest.java
@@ -1,13 +1,15 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by andrewrogers on 7/1/15.
  */
-public class AssetTest extends TestCase {
+public class AssetTest {
 
   @Test
   public void testAssetTypeNative() {

--- a/src/test/java/org/stellar/base/KeypairTest.java
+++ b/src/test/java/org/stellar/base/KeypairTest.java
@@ -1,17 +1,18 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Assert;
+import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-public class KeypairTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class KeypairTest {
 
   private static final String SEED = "1123740522f11bfef6b3671f51e159ccf589ccf8965262dd5f97d1721d383dd4";
 
-  @org.junit.Test
+  @Test
   public void testSign() {
     String expectedSig = "587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
     Keypair keypair = Keypair.fromSecretSeed(Util.hexToBytes(SEED));
@@ -20,7 +21,7 @@ public class KeypairTest extends TestCase {
     Assert.assertArrayEquals(Util.hexToBytes(expectedSig), sig);
   }
 
-  @org.junit.Test
+  @Test
   public void testVerifyTrue() throws Exception {
     String sig = "587d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
     String data = "hello world";
@@ -28,7 +29,7 @@ public class KeypairTest extends TestCase {
     Assert.assertTrue(keypair.verify(data.getBytes(), Util.hexToBytes(sig)));
   }
 
-  @org.junit.Test
+  @Test
   public void testVerifyFalse() throws Exception {
     String badSig = "687d4b472eeef7d07aafcd0b049640b0bb3f39784118c2e2b73a04fa2f64c9c538b4b2d0f5335e968a480021fdc23e98c0ddf424cb15d8131df8cb6c4bb58309";
     byte[] corrupt = {0x00};
@@ -38,7 +39,7 @@ public class KeypairTest extends TestCase {
     Assert.assertFalse(keypair.verify(data.getBytes(), corrupt));
   }
 
-  @org.junit.Test
+  @Test
   public void testFromSecretSeed() throws Exception {
     Map<String, String> keypairs = new HashMap<String, String>();
     keypairs.put("SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE", "GCZHXL5HXQX5ABDM26LHYRCQZ5OJFHLOPLZX47WEBP3V2PF5AVFK2A5D");

--- a/src/test/java/org/stellar/base/MemoTest.java
+++ b/src/test/java/org/stellar/base/MemoTest.java
@@ -1,14 +1,16 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.apache.commons.codec.DecoderException;
 import org.junit.Test;
 import org.stellar.base.xdr.MemoType;
 
 import java.util.Arrays;
 
-public class MemoTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MemoTest {
     @Test
     public void testMemoNone() {
         org.stellar.base.xdr.Memo memo = Memo.none();
@@ -33,6 +35,16 @@ public class MemoTest extends TestCase {
     public void testMemoTextTooLong() {
         try {
             Memo.text("12345678901234567890123456789");
+            fail();
+        } catch (RuntimeException exception) {
+            assertTrue(exception.getMessage().contains("text must be <= 28 bytes."));
+        }
+    }
+
+    @Test
+    public void testMemoTextTooLongUtf8() {
+        try {
+            Memo.text("价值交易的开源协议!!");
             fail();
         } catch (RuntimeException exception) {
             assertTrue(exception.getMessage().contains("text must be <= 28 bytes."));

--- a/src/test/java/org/stellar/base/NetworkTest.java
+++ b/src/test/java/org/stellar/base/NetworkTest.java
@@ -1,10 +1,10 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
-public class NetworkTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class NetworkTest {
 
     public void tearDown() {
         Network.useTestNetwork();

--- a/src/test/java/org/stellar/base/OperationTest.java
+++ b/src/test/java/org/stellar/base/OperationTest.java
@@ -1,14 +1,13 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Assert;
 import org.junit.Test;
-import org.stellar.base.xdr.Int32;
 
 import java.io.IOException;
 
-public class OperationTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class OperationTest {
 
   @Test
   public void testCreateAccountOperation() throws FormatException, IOException, AssetCodeLengthInvalidException {
@@ -25,15 +24,16 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     CreateAccountOperation parsedOperation = (CreateAccountOperation) Operation.fromXdr(xdr);
 
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
-    Assert.assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
-    Assert.assertEquals(startingAmount, parsedOperation.getStartingBalance());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
+    assertEquals(startingAmount, parsedOperation.getStartingBalance());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAAAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAAAAAD6A==",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testPaymentOperation() throws FormatException, IOException, AssetCodeLengthInvalidException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -50,16 +50,17 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     PaymentOperation parsedOperation = (PaymentOperation) Operation.fromXdr(xdr);
 
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
-    Assert.assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
     Assert.assertTrue(parsedOperation.getAsset() instanceof AssetTypeNative);
-    Assert.assertEquals(amount, parsedOperation.getAmount());
+    assertEquals(amount, parsedOperation.getAmount());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAEAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAAAAAAAAAAAA+g=",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testPathPaymentOperation() throws FormatException, IOException, AssetCodeLengthInvalidException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -88,18 +89,19 @@ public class OperationTest extends TestCase {
     PathPaymentOperation parsedOperation = (PathPaymentOperation) Operation.fromXdr(xdr);
 
     Assert.assertTrue(parsedOperation.getSendAsset() instanceof AssetTypeNative);
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
-    Assert.assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
-    Assert.assertEquals(sendMax, parsedOperation.getSendMax());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
+    assertEquals(sendMax, parsedOperation.getSendMax());
     Assert.assertTrue(parsedOperation.getDestAsset() instanceof AssetTypeCreditAlphaNum4);
-    Assert.assertEquals(destAmount, parsedOperation.getDestAmount());
-    Assert.assertEquals(path.length, parsedOperation.getPath().length);
+    assertEquals(destAmount, parsedOperation.getDestAmount());
+    assertEquals(path.length, parsedOperation.getPath().length);
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAIAAAAAAAAAAAAAA+gAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAABVVNEAAAAAACNlYd30HdCuLI54eyYjyX/fDyH9IJWIr/hKDcXKQbq1QAAAAAAAAPoAAAAAgAAAAFVU0QAAAAAACoIKnpnw8rtrfxa276dFZo1C19mDqWXtG4ufhWrLUd1AAAAAlRFU1RURVNUAAAAAAAAAABE/ttVl8BLV0csW/xgXtbXOVf1lMyDluMiafl0IDVFIg==",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testChangeTrustOperation() throws FormatException, IOException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -114,15 +116,16 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     ChangeTrustOperation parsedOperation = (ChangeTrustOperation) Operation.fromXdr(xdr);
 
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
     Assert.assertTrue(parsedOperation.getAsset() instanceof AssetTypeNative);
-    Assert.assertEquals(limit, parsedOperation.getLimit());
+    assertEquals(limit, parsedOperation.getLimit());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAYAAAAAf/////////8=",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testAllowTrustOperation() throws IOException, FormatException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -139,16 +142,17 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     AllowTrustOperation parsedOperation = (AllowTrustOperation) Operation.fromXdr(xdr);
 
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
-    Assert.assertEquals(trustor.getAddress(), parsedOperation.getTrustor().getAddress());
-    Assert.assertEquals(assetCode, parsedOperation.getAssetCode());
-    Assert.assertEquals(authorize, parsedOperation.getAuthorize());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(trustor.getAddress(), parsedOperation.getTrustor().getAddress());
+    assertEquals(assetCode, parsedOperation.getAssetCode());
+    assertEquals(authorize, parsedOperation.getAuthorize());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAcAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxAAAAABVVNEQQAAAAE=",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testSetOptionsOperation() throws FormatException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -182,23 +186,24 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     SetOptionsOperation parsedOperation = (SetOptionsOperation) SetOptionsOperation.fromXdr(xdr);
 
-    Assert.assertEquals(inflationDestination.getAddress(), parsedOperation.getInflationDestination().getAddress());
-    Assert.assertEquals(clearFlags, parsedOperation.getClearFlags());
-    Assert.assertEquals(setFlags, parsedOperation.getSetFlags());
-    Assert.assertEquals(masterKeyWeight, parsedOperation.getMasterKeyWeight());
-    Assert.assertEquals(lowThreshold, parsedOperation.getLowThreshold());
-    Assert.assertEquals(mediumThreshold, parsedOperation.getMediumThreshold());
-    Assert.assertEquals(highThreshold, parsedOperation.getHighThreshold());
-    Assert.assertEquals(homeDomain, parsedOperation.getHomeDomain());
-    Assert.assertEquals(signer.getAddress(), parsedOperation.getSigner().getAddress());
-    Assert.assertEquals(signerWeight, parsedOperation.getSignerWeight());
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(inflationDestination.getAddress(), parsedOperation.getInflationDestination().getAddress());
+    assertEquals(clearFlags, parsedOperation.getClearFlags());
+    assertEquals(setFlags, parsedOperation.getSetFlags());
+    assertEquals(masterKeyWeight, parsedOperation.getMasterKeyWeight());
+    assertEquals(lowThreshold, parsedOperation.getLowThreshold());
+    assertEquals(mediumThreshold, parsedOperation.getMediumThreshold());
+    assertEquals(highThreshold, parsedOperation.getHighThreshold());
+    assertEquals(homeDomain, parsedOperation.getHomeDomain());
+    assertEquals(signer.getAddress(), parsedOperation.getSigner().getAddress());
+    assertEquals(signerWeight, parsedOperation.getSignerWeight());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAUAAAABAAAAAO3gUmG83C+VCqO6FztuMtXJF/l7grZA7MjRzqdZ9W8QAAAAAQAAAAEAAAABAAAAAQAAAAEAAAABAAAAAQAAAAIAAAABAAAAAwAAAAEAAAAEAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAABAAAAAET+21WXwEtXRyxb/GBe1tc5V/WUzIOW4yJp+XQgNUUiAAAAAQ==",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testSetOptionsOperationSingleField() {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -213,23 +218,24 @@ public class OperationTest extends TestCase {
     org.stellar.base.xdr.Operation xdr = operation.toXdr();
     SetOptionsOperation parsedOperation = (SetOptionsOperation) SetOptionsOperation.fromXdr(xdr);
 
-    Assert.assertEquals(null, parsedOperation.getInflationDestination());
-    Assert.assertEquals(null, parsedOperation.getClearFlags());
-    Assert.assertEquals(null, parsedOperation.getSetFlags());
-    Assert.assertEquals(null, parsedOperation.getMasterKeyWeight());
-    Assert.assertEquals(null, parsedOperation.getLowThreshold());
-    Assert.assertEquals(null, parsedOperation.getMediumThreshold());
-    Assert.assertEquals(null, parsedOperation.getHighThreshold());
-    Assert.assertEquals(homeDomain, parsedOperation.getHomeDomain());
-    Assert.assertEquals(null, parsedOperation.getSigner());
-    Assert.assertEquals(null, parsedOperation.getSignerWeight());
-    Assert.assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
+    assertEquals(null, parsedOperation.getInflationDestination());
+    assertEquals(null, parsedOperation.getClearFlags());
+    assertEquals(null, parsedOperation.getSetFlags());
+    assertEquals(null, parsedOperation.getMasterKeyWeight());
+    assertEquals(null, parsedOperation.getLowThreshold());
+    assertEquals(null, parsedOperation.getMediumThreshold());
+    assertEquals(null, parsedOperation.getHighThreshold());
+    assertEquals(homeDomain, parsedOperation.getHomeDomain());
+    assertEquals(null, parsedOperation.getSigner());
+    assertEquals(null, parsedOperation.getSignerWeight());
+    assertEquals(source.getAddress(), parsedOperation.getSourceAccount().getAddress());
 
     assertEquals(
           "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAtzdGVsbGFyLm9yZwAAAAAA",
           operation.toXdrBase64());
   }
 
+  @Test
   public void testManagerOfferOperation() throws IOException, FormatException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -254,17 +260,18 @@ public class OperationTest extends TestCase {
     Assert.assertTrue(parsedOperation.getSelling() instanceof AssetTypeNative);
     Assert.assertTrue(parsedOperation.getBuying() instanceof AssetTypeCreditAlphaNum4);
     Assert.assertTrue(parsedOperation.getBuying().equals(buying));
-    Assert.assertEquals(amount, parsedOperation.getAmount());
-    Assert.assertEquals(price, parsedOperation.getPrice());
-    Assert.assertEquals(priceObj.getNumerator(), 5333399);
-    Assert.assertEquals(priceObj.getDenominator(), 6250000);
-    Assert.assertEquals(offerId, parsedOperation.getOfferId());
+    assertEquals(amount, parsedOperation.getAmount());
+    assertEquals(price, parsedOperation.getPrice());
+    assertEquals(priceObj.getNumerator(), 5333399);
+    assertEquals(priceObj.getDenominator(), 6250000);
+    assertEquals(offerId, parsedOperation.getOfferId());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAMAAAAAAAAAAVVTRAAAAAAARP7bVZfAS1dHLFv8YF7W1zlX9ZTMg5bjImn5dCA1RSIAAAAAAAAAZABRYZcAX14QAAAAAAAAAAE=",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testCreatePassiveOfferOperation() throws IOException, FormatException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -287,16 +294,17 @@ public class OperationTest extends TestCase {
     Assert.assertTrue(parsedOperation.getSelling() instanceof AssetTypeNative);
     Assert.assertTrue(parsedOperation.getBuying() instanceof AssetTypeCreditAlphaNum4);
     Assert.assertTrue(parsedOperation.getBuying().equals(buying));
-    Assert.assertEquals(amount, parsedOperation.getAmount());
-    Assert.assertEquals(price, parsedOperation.getPrice());
-    Assert.assertEquals(priceObj.getNumerator(), 36731261);
-    Assert.assertEquals(priceObj.getDenominator(), 12500000);
+    assertEquals(amount, parsedOperation.getAmount());
+    assertEquals(price, parsedOperation.getPrice());
+    assertEquals(priceObj.getNumerator(), 36731261);
+    assertEquals(priceObj.getDenominator(), 12500000);
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAQAAAAAAAAAAVVTRAAAAAAARP7bVZfAS1dHLFv8YF7W1zlX9ZTMg5bjImn5dCA1RSIAAAAAAAAAZAIweX0Avrwg",
             operation.toXdrBase64());
   }
 
+  @Test
   public void testAccountMergeOperation() throws IOException, FormatException {
     // GC5SIC4E3V56VOHJ3OZAX5SJDTWY52JYI2AFK6PUGSXFVRJQYQXXZBZF
     Keypair source = Keypair.fromSecretSeed("SC4CGETADVYTCR5HEAVZRB3DZQY5Y4J7RFNJTRA6ESMHIPEZUSTE2QDK");
@@ -311,7 +319,7 @@ public class OperationTest extends TestCase {
 
     AccountMergeOperation parsedOperation = (AccountMergeOperation) Operation.fromXdr(xdr);
 
-    Assert.assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
+    assertEquals(destination.getAddress(), parsedOperation.getDestination().getAddress());
 
     assertEquals(
             "AAAAAQAAAAC7JAuE3XvquOnbsgv2SRztjuk4RoBVefQ0rlrFMMQvfAAAAAgAAAAA7eBSYbzcL5UKo7oXO24y1ckX+XuCtkDsyNHOp1n1bxA=",

--- a/src/test/java/org/stellar/base/PriceTest.java
+++ b/src/test/java/org/stellar/base/PriceTest.java
@@ -1,10 +1,10 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
-public class PriceTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+
+public class PriceTest {
     @Test
     public void testFromDouble() {
         PriceTestCase[] tests = {

--- a/src/test/java/org/stellar/base/StrKeyTest.java
+++ b/src/test/java/org/stellar/base/StrKeyTest.java
@@ -6,7 +6,10 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-public class StrKeyTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class StrKeyTest {
     @Test
     public void testDecodeEncode() throws IOException, FormatException {
         String seed = "SDJHRQF4GCMIIKAAAQ6IHY42X73FQFLHUULAPSKKD4DFDM7UXWWCRHBE";

--- a/src/test/java/org/stellar/base/TransactionTest.java
+++ b/src/test/java/org/stellar/base/TransactionTest.java
@@ -1,12 +1,14 @@
 package org.stellar.base;
 
-import junit.framework.TestCase;
-
 import org.junit.Test;
 
 import java.io.IOException;
 
-public class TransactionTest extends TestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class TransactionTest {
 
     public void tearDown() {
         Network.useTestNetwork();


### PR DESCRIPTION
This includes 3 minor fixes:

1. In [StellarExample.java](https://github.com/stellar/java-stellar-base/blob/b6539bc8207d5122711a7cc66752f0a81c21729a/examples/java/StellarExample.java#L17), change the amount type in PaymentOperation to be long/Long.
1.  Unify junit test case setup: removing TestCase inheritence, using annotations.
1. Add text memo containing utf8 chars but too long case (see also https://github.com/stellar/js-stellar-base/issues/55).